### PR TITLE
Fixed `PropertyInfo` Default Usage from Dictionary

### DIFF
--- a/include/godot_cpp/core/property_info.hpp
+++ b/include/godot_cpp/core/property_info.hpp
@@ -80,7 +80,9 @@ struct PropertyInfo {
 		dict["type"] = type;
 		dict["hint"] = hint;
 		dict["hint_string"] = hint_string;
-		dict["usage"] = usage;
+		if (usage != PROPERTY_USAGE_NONE) {
+			dict["usage"] = usage;
+		}
 		return dict;
 	}
 


### PR DESCRIPTION
The editor currently doesn’t respect `PropertyInfo` usage flags when adding new Editor Settings through GDExtension. It always assigns a default usage value, which triggers warnings on startup.

This PR adds a check for `PROPERTY_USAGE_NONE` and skips setting the usage field entirely in that case, preventing the warning from being generated at startup.

```cpp
if (usage != PROPERTY_USAGE_NONE) {
    dict["usage"] = usage;
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Property information serialization now omits default values, reducing unnecessary data in serialized output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->