### PR TITLE
CI: Update Windows runners to `windows-2022` in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -50,7 +50,7 @@ jobs:
             run-tests: false
 
           - name: 🏁 Windows (x86_64, MSVC)
-            os: windows-2019
+            os: windows-2022
             platform: windows
             compiler: msvc
             build-flags: --config Release
@@ -59,7 +59,7 @@ jobs:
             run-tests: false
 
           - name: 🏁 Windows (x86_64, MinGW, Ninja)
-            os: windows-2019
+            os: windows-2022
             platform: windows
             compiler: mingw
             config-flags:

--- a/.github/workflows/ci-scons.yml
+++ b/.github/workflows/ci-scons.yml
@@ -41,7 +41,7 @@ jobs:
             cache-name: linux-x86_64-f64
 
           - name: 🏁 Windows (x86_64, MSVC)
-            os: windows-2019
+            os: windows-2022
             platform: windows
             artifact-name: redot-cpp-windows-msvc2019-x86_64-release
             artifact-path: bin/libredot-cpp.windows.template_release.x86_64.lib
@@ -49,7 +49,7 @@ jobs:
             cache-name: windows-x86_64-msvc
 
           - name: 🏁 Windows (x86_64, MinGW)
-            os: windows-2019
+            os: windows-2022
             platform: windows
             artifact-name: redot-cpp-linux-mingw-x86_64-release
             artifact-path: bin/libredot-cpp.windows.template_release.x86_64.a


### PR DESCRIPTION
GH Actions do not have Windows server 2019 runners anymore. This PR bumps them to Windows Server 2022.