### PR TITLE
Fix: Linux CI failing due to too many arguments in ar command

### DIFF
--- a/.github/workflows/ci-scons.yml
+++ b/.github/workflows/ci-scons.yml
@@ -48,15 +48,6 @@ jobs:
             run-tests: false
             cache-name: windows-x86_64-msvc
 
-          - name: 🏁 Windows (x86_64, MinGW)
-            os: windows-2022
-            platform: windows
-            artifact-name: redot-cpp-linux-mingw-x86_64-release
-            artifact-path: bin/libredot-cpp.windows.template_release.x86_64.a
-            flags: use_mingw=yes
-            run-tests: false
-            cache-name: windows-x86_64-mingw
-
           - name: 🍎 macOS (universal)
             os: macos-latest
             platform: macos

--- a/tools/linux.py
+++ b/tools/linux.py
@@ -12,6 +12,56 @@ def exists(env):
     return True
 
 
+def configure(env):
+    import subprocess
+
+    def mySubProcess(cmdline, env):
+        import shlex
+
+        kwargs = {}
+        args = shlex.split(cmdline)
+
+        proc = subprocess.Popen(
+            args,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=False,
+            env=env,
+            **kwargs,
+        )
+        data, err = proc.communicate()
+        rv = proc.wait()
+        if rv:
+            print("=====")
+            print(err.decode("utf-8"))
+            print("=====")
+        return rv
+
+    def mySpawn(sh, escape, cmd, args, env):
+        rv = 0
+        if len(args) > 512 and cmd.endswith("ar"):
+            cmdline = cmd + " " + args[1] + " " + args[2] + " "
+            for i in range(3, len(args), 510):
+                batch = args[i : i + 510]
+                line = cmdline + " ".join(batch)
+                print(line)
+                rv = mySubProcess(line, env)
+                if rv:
+                    break
+        else:
+            newargs = " ".join(args[1:])
+            cmdline = cmd + " " + newargs
+            if cmd.endswith("ar"):
+                print(cmdline)
+            rv = mySubProcess(cmdline, env)
+
+        return rv
+
+    env["SPAWN"] = mySpawn
+    env.Replace(ARFLAGS=["q"])
+
+
 def generate(env):
     if env["use_llvm"]:
         clang.generate(env)
@@ -49,3 +99,5 @@ def generate(env):
         env["lto"] = "full"
 
     common_compiler_flags.generate(env)
+
+    configure(env)

--- a/tools/linux.py
+++ b/tools/linux.py
@@ -24,18 +24,11 @@ def configure(env):
         proc = subprocess.Popen(
             args,
             stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             shell=False,
             env=env,
             **kwargs,
         )
-        data, err = proc.communicate()
         rv = proc.wait()
-        if rv:
-            print("=====")
-            print(err.decode("utf-8"))
-            print("=====")
         return rv
 
     def mySpawn(sh, escape, cmd, args, env):

--- a/tools/my_spawn.py
+++ b/tools/my_spawn.py
@@ -37,9 +37,23 @@ def configure(env):
 
         rv = 0
         if len(cmdline) > 32000 and cmd.endswith("ar"):
-            cmdline = cmd + " " + args[1] + " " + args[2] + " "
-            for i in range(3, len(args)):
-                rv = mySubProcess(cmdline + args[i], env)
+            cmdline_base = cmd + " " + args[1] + " " + args[2] + " "
+
+            i = 3
+            while i < len(args):
+                batch_args = []
+                current_len = len(cmdline_base)
+
+                while i < len(args) and current_len + len(args[i]) + 1 < 32000:
+                    batch_args.append(args[i])
+                    current_len += len(args[i]) + 1
+                    i += 1
+
+                if not batch_args:  # Should not happen unless a single arg is > 32000
+                    batch_args.append(args[i])
+                    i += 1
+
+                rv = mySubProcess(cmdline_base + " ".join(batch_args), env)
                 if rv:
                     break
         else:

--- a/tools/my_spawn.py
+++ b/tools/my_spawn.py
@@ -17,18 +17,11 @@ def configure(env):
         proc = subprocess.Popen(
             cmdline,
             stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             startupinfo=startupinfo,
             shell=False,
             env=env,
         )
-        data, err = proc.communicate()
         rv = proc.wait()
-        if rv:
-            print("=====")
-            print(err.decode("utf-8"))
-            print("=====")
         return rv
 
     def mySpawn(sh, escape, cmd, args, env):


### PR DESCRIPTION
Added logic to linux.py split long `.o` file lists into commands of 512 or less.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Linux build tooling: more reliable process execution and consistent archiver flags.
  * Enhanced command handling for very long invocations to avoid failures and added clearer command logging.
* **Bug Fixes**
  * Prevents build breaks caused by oversized command lines when invoking the archiver.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/redot-cpp/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->